### PR TITLE
Enable auto-detection for Eagle speculators format models

### DIFF
--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -395,7 +395,6 @@ class EngineArgs:
 
     speculative_config: Optional[Dict[str, Any]] = None
     draft_tensor_parallel_size: Optional[int] = None
-    no_auto_speculative: bool = False
 
     show_hidden_metrics_for_version: Optional[str] = \
         ObservabilityConfig.show_hidden_metrics_for_version
@@ -774,13 +773,8 @@ class EngineArgs:
             type=int,
             default=None,
             help="Number of tensor parallel replicas for the draft model. "
-            "Only used with speculative decoding.")
-        speculative_group.add_argument(
-            "--no-auto-speculative",
-            action="store_true",
-            default=False,
-            help="Disable automatic detection of speculators format models "
-            "for speculative decoding.")
+            "Only used with speculative decoding. "
+            "Note: draft_tensor_parallel_size > 1 is not supported at the moment.")
 
         # Observability arguments
         observability_kwargs = get_kwargs(ObservabilityConfig)
@@ -889,8 +883,7 @@ class EngineArgs:
     @classmethod
     def from_cli_args(cls, args: argparse.Namespace):
         # Auto-detect speculators format models
-        if (args.model and not args.speculative_config and 
-            not getattr(args, 'no_auto_speculative', False)):
+        if args.model and not args.speculative_config:
             from vllm.transformers_utils.configs import extract_speculators_info
             from vllm.logger import init_logger
             logger = init_logger(__name__)

--- a/vllm/transformers_utils/configs/__init__.py
+++ b/vllm/transformers_utils/configs/__init__.py
@@ -7,7 +7,8 @@ from vllm.transformers_utils.configs.dbrx import DbrxConfig
 from vllm.transformers_utils.configs.deepseek_vl2 import DeepseekVLV2Config
 from vllm.transformers_utils.configs.eagle import EAGLEConfig
 from vllm.transformers_utils.configs.exaone import ExaoneConfig
-from vllm.transformers_utils.configs.speculators_eagle import SpeculatorsEagleConfig
+from vllm.transformers_utils.configs.speculators_eagle import (
+    SpeculatorsEagleConfig, extract_speculators_info)
 # RWConfig is for the original tiiuae/falcon-40b(-instruct) and
 # tiiuae/falcon-7b(-instruct) models. Newer Falcon models will use the
 # `FalconConfig` class from the official HuggingFace transformers library.
@@ -42,6 +43,7 @@ __all__ = [
     "EAGLEConfig",
     "ExaoneConfig",
     "SpeculatorsEagleConfig",
+    "extract_speculators_info",
     "MiniMaxText01Config",
     "MiniMaxVL01Config",
     "MllamaConfig",

--- a/vllm/transformers_utils/configs/speculators_eagle.py
+++ b/vllm/transformers_utils/configs/speculators_eagle.py
@@ -335,6 +335,10 @@ def extract_speculators_info(model_path: Union[str, os.PathLike]) -> Optional[di
             "method": method,
             "num_tokens": num_tokens
         }
-    except Exception:
-        # If any error occurs, treat as not speculators format
+    except Exception as e:
+        from vllm.logger import init_logger
+        logger = init_logger(__name__)
+        logger.debug("Failed to extract speculators info from %s.",
+                     model_path,
+                     exc_info=e)
         return None


### PR DESCRIPTION
## Summary

  This PR introduces auto-detection for Eagle models in "speculators" format, dramatically simplifying the UX for
  speculative decoding. Users can now simply run `vllm serve <speculators-model>` and vLLM will automatically configure
  everything needed for speculative decoding.

  ### Before (current behavior)
  ```bash
  vllm serve meta-llama/Llama-3.3-70B-Instruct \
    --speculative-config '{"method": "eagle3", "model": "yuhuili/EAGLE3-LLaMA3.3-Instruct-70B", "num_speculative_tokens": 5,
   "draft_tensor_parallel_size": 1}'
```
  After (with this PR)
```bash
  vllm serve nm-testing/eagle-llama3.1-8b-instruct
```
  
  ## Motivation

  Eagle models in "speculators" format contain all the necessary information for speculative decoding in their
  configuration:
  - Target model name
  - Speculative decoding method (eagle/eagle3)
  - Number of speculative tokens
  - Draft model architecture

  Previously, users had to manually extract this information and construct a complex JSON configuration. This PR automates
  that process.

  ## Implementation Approach

  1. Detection Function

  Added `extract_speculators_info()` in `vllm/transformers_utils/configs/speculators_eagle.py` that:
  - Checks if a model is in speculators format by looking for `speculators_model_type` in config
  - Extracts target model from either `speculators_config.target_config.model_name` or
  `speculators_config.verifier.name_or_path`
  - Returns method, target model, and number of speculative tokens

  2. Auto-Detection in Engine Args

  Modified `EngineArgs.from_cli_args()` to:
  - Check if the provided model is speculators format when no `--speculative-config` is provided
  - Automatically build the speculative config from extracted metadata
  - Swap the model argument to point to the target model
  - Update the tokenizer to use the target model (fixing tokenizer loading issues)
  - Log the auto-detection process for transparency

  3. New CLI Arguments

  Added two new arguments for fine-grained control:
  - `--draft-tensor-parallel-size`: Set tensor parallel size for the draft model
  - `--no-auto-speculative`: Disable auto-detection when needed

  Examples

  Basic Usage

  #### Eagle-1 model
  `vllm serve nm-testing/eagle-llama3.1-8b-instruct`

  #### Eagle-3 model  
  vllm serve `nm-testing/eagle3-llama3.1-8b-instruct-speculators`

  #### HASS variant
  `vllm serve nm-testing/hass-llama3.1-8b-layernorms`

  With Custom Settings
```bash
  # Set draft model tensor parallel size
  vllm serve nm-testing/EAGLE3-LLaMA3.3-Instruct-70B-speculators --draft-tensor-parallel-size 1
 ```

  #### Use with other vLLM options
  ```bash
  vllm serve nm-testing/eagle3-llama3.1-8b-instruct-speculators \
    --max-model-len 8192 \
    --gpu-memory-utilization 0.8
```
  #### Opt-Out of Auto-Detection

 Disable auto-detection and load as regular model
  `vllm serve some-speculators-model --no-auto-speculative`

  Backward Compatibility

  ```bash
  # Explicit configuration still works

  vllm serve meta-llama/Llama-3.3-70B-Instruct \
    --speculative-config '{"method": "eagle3", "model": "yuhuili/EAGLE3-LLaMA3.3-Instruct-70B", "num_speculative_tokens": 
  5}'
```
  ## What Gets Auto-Configured

  When a speculators format model is detected, the following happens automatically:

  1. Target model is extracted and set as the main model
  2. Draft model is set to the provided speculators model path
  3. Method is set based on `speculators_model_type` (eagle/eagle3)
  4. Number of speculative tokens is extracted from config
  5. Tokenizer is updated to use the target model

  The auto-detection logs show what's happening:
  ```
  INFO ... 🦅 Auto-detected Eagle speculators format model
  INFO ...   Target model: meta-llama/Meta-Llama-3.1-8B-Instruct
  INFO ...   Draft model: nm-testing/eagle3-llama3.1-8b-instruct-speculators
  INFO ...   Method: eagle3
  INFO ...   Speculative tokens: 5
```
  #### Testing

  Tested with various Eagle models:
  - ✅ Eagle-1 models 
  - ✅ Eagle-3 models 
  - ✅ HASS variants 

  Related Issues

  This PR builds on top of #20436 (Eagle Qwen support) and should be merged after it.