### PR TITLE
Fix for Normal Qwen Model Serving Error

### DIFF
--- a/vllm/model_executor/models/qwen2.py
+++ b/vllm/model_executor/models/qwen2.py
@@ -352,8 +352,8 @@ class Qwen2Model(nn.Module):
             hidden_states = intermediate_tensors["hidden_states"]
             residual = intermediate_tensors["residual"]
 
+        aux_hidden_states = []
         if len(self.aux_hidden_state_layers) > 0:
-            aux_hidden_states = []
             for idx, layer in enumerate(
                     self.layers[self.start_layer:self.end_layer]):
                 if idx in self.aux_hidden_state_layers:


### PR DESCRIPTION
## Issue
When serving a normal Qwen model (e.g., `Qwen/Qwen3-8B`), vLLM would crash with a NameError because `aux_hidden_states` was referenced but not defined.

## Root Cause
In the Qwen2Model forward method, we added Eagle3 support that collects auxiliary hidden states. However, the variable `aux_hidden_states` was only defined inside an if block that checks for Eagle models, but was referenced outside that block for all models.

## Solution
Initialize `aux_hidden_states` as an empty list before the conditional block so it's always defined.

```python
# Before fix (would cause NameError for normal models):
if len(self.aux_hidden_state_layers) > 0:
    aux_hidden_states = []  # Only defined for Eagle models
    # ... collect aux states ...
else:
    # ... normal forward pass ...

# Later in code:
if len(aux_hidden_states) > 0:  # NameError here for normal models!
    return hidden_states, aux_hidden_states

# After fix:
aux_hidden_states = []  # Always defined
if len(self.aux_hidden_state_layers) > 0:
    # ... collect aux states ...
else:
    # ... normal forward pass ...
```

## Testing
Normal Qwen models should now work correctly:
```bash
CUDA_VISIBLE_DEVICES=1 vllm serve Qwen/Qwen3-8B
```